### PR TITLE
chore(wasm): get wasm from docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pyieml.egg-info
 venv
 assets/erroneous_files
 build_cache
+binding/wasm/parser_wasm.js
+binding/wasm/parser_wasm.wasm

--- a/Dockerfile_build_wasm
+++ b/Dockerfile_build_wasm
@@ -8,16 +8,12 @@ COPY cmake /libieml/cmake
 COPY thirdparty /libieml/thirdparty 
 COPY include /libieml/include
 COPY src /libieml/src
+COPY build_wasm.sh /libieml/build_wasm.sh
 # wasm related
 COPY binding/wasm /libieml/binding/wasm
 # need to add this pkg-config file because emscripten do not provide it and antlr needs it
 COPY binding/wasm/uuid.pc $EMSDK/upstream/emscripten/cache/sysroot/lib/pkgconfig/
 
-# build WASM target using emscripten 
-# the generated .js and .wasm are generated in /libieml/build/binding/wasm/parser_wasm.{js,wasm}
-RUN mkdir build && \
-    cd build && \
-    emcmake cmake -DBUILD_WASM:bool=True .. &&\
-    emmake make -j $NB_CORES
+VOLUME ["/libieml/build"]
 
-CMD ["ls", "/libieml/build/binding/wasm/"]
+CMD ["bash", "./build_wasm.sh"]

--- a/binding/wasm/.npmignore
+++ b/binding/wasm/.npmignore
@@ -1,0 +1,5 @@
+build.js
+CMakeLists.txt 
+main.cpp 
+run_test.html
+uuid.pc

--- a/binding/wasm/README.md
+++ b/binding/wasm/README.md
@@ -1,0 +1,34 @@
+# Parser Wasm
+
+Wasm Parser for [IEML](https://intlekt.io/ieml/).
+
+This version is not up to date. [Contact us](https://intlekt.io/contact/) if you want a version up to date.
+
+## Installation
+
+```bash
+npm install @intlekt/parser-wasm
+yarn add @intlekt/parser-wasm
+```
+
+## Usage
+
+```html
+<html>
+  <head></head>
+  <body style="display: grid; grid-template-columns: 50% auto">
+    <textarea id="area"></textarea>
+    <div id="result"></div>
+    <script type="module">
+      import { loadWorker } from '@intlekt/parser-wasm'
+      loadWorker().then(worker => {
+        document.getElementById('area').addEventListener('change', e => {
+          worker.parse_project([''], [e.target.value]).then(res => {
+            document.getElementById('result').textContent = JSON.stringify(res)
+          })
+        })
+      })
+    </script>
+  </body>
+</html>
+```

--- a/binding/wasm/build.js
+++ b/binding/wasm/build.js
@@ -1,0 +1,13 @@
+import { copyFileSync, constants } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const buildPath = path.resolve(__dirname, '../../build/binding/wasm')
+
+const files = ['parser_wasm.wasm', 'parser_wasm.js']
+
+files.forEach(file => {
+  copyFileSync(path.join(buildPath, file), path.join(__dirname, file))
+})

--- a/binding/wasm/example.html
+++ b/binding/wasm/example.html
@@ -1,10 +1,9 @@
 <html>
-<head></head>
-<body style="display: grid;grid-template-columns: 50% auto;">
-
+  <head></head>
+  <body style="display: grid; grid-template-columns: 50% auto">
     <textarea id="area"></textarea>
     <div id="result"></div>
-<!-- 
+    <!-- 
     <script src='parser_wasm.js'></script>
     <script>
 
@@ -49,14 +48,14 @@
         })
     </script> -->
     <script type="module">
-        import {loadWorker} from "./parser_wasm.loader.js"
-        loadWorker().then((worker) => {
-            document.getElementById('area').addEventListener('change', (e)=>{
-                worker.parse_project([""], [e.target.value]).then((res) => {
-                    document.getElementById('result').textContent = JSON.stringify(res);
-                })
-            })
-        });
+      import { loadWorker } from './parser_wasm.loader.js'
+      loadWorker().then(worker => {
+        document.getElementById('area').addEventListener('change', e => {
+          worker.parse_project([''], [e.target.value]).then(res => {
+            document.getElementById('result').textContent = JSON.stringify(res)
+          })
+        })
+      })
     </script>
-</body>
+  </body>
 </html>

--- a/binding/wasm/package.json
+++ b/binding/wasm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@intlekt/parser-wasm",
+  "version": "2.37.3",
+  "description": "",
+  "main": "parser_wasm.loader.js",
+  "scripts": {
+    "build": "node build.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "author": "Thibault Friedrich",
+  "private": false,
+  "license": "ISC"
+}

--- a/binding/wasm/parser_wasm.loader.js
+++ b/binding/wasm/parser_wasm.loader.js
@@ -1,74 +1,69 @@
-export {loadWorker, loadWorker as default};
-
-function loadWorker() {
-    var worker = null;
-    if (window && window.Worker) {
-        worker = new Promise((resolve, reject) => {
-            var w = new Worker('parser_wasm.worker.js');
-            init_worker(w).then(() => resolve(parserInterface(w)))
-        });
-    } else {
-        throw Error("Web worker not supported");
-    }
-    return worker;
+export function loadWorker() {
+  var worker = null
+  if (window && window.Worker) {
+    worker = new Promise((resolve, reject) => {
+      var w = new Worker('parser_wasm.worker.js')
+      init_worker(w).then(() => resolve(parserInterface(w)))
+    })
+  } else {
+    throw Error('Web worker not supported')
+  }
+  return worker
 }
+
+export default loadWorker
 
 function parserInterface(w) {
-    return {
-        'parse_project': (file_ids, file_contents) => parse_project(w, file_ids, file_contents)
-    }
+  return {
+    parse_project: (file_ids, file_contents) =>
+      parse_project(w, file_ids, file_contents),
+  }
 }
-
 
 function init_worker(w) {
-    return new Promise((resolve, reject) => {
-        w.postMessage({
-            action: "init"
-        })
-
-        w.onmessage = (event) => {
-            if (event['data']['action'] == 'loaded') 
-                resolve();
-            else if (event['data']['action'] == 'parse_project_result') 
-                resolve_parse(event['data']);
-            else 
-                throw Error("Expected loaded event !");
-        }
+  return new Promise((resolve, reject) => {
+    w.postMessage({
+      action: 'init',
     })
+
+    w.onmessage = event => {
+      if (event['data']['action'] == 'loaded') resolve()
+      else if (event['data']['action'] == 'parse_project_result')
+        resolve_parse(event['data'])
+      else throw Error('Expected loaded event !')
+    }
+  })
 }
 
-
-var _id_to_parse_promise = {};
+var _id_to_parse_promise = {}
 
 function resolve_parse(event_data) {
-    const id = event_data['id'];
-    if (!(id in _id_to_parse_promise)) {
-        throw Error("Got an invalid parse id. No parse job queued with this id.")
-    }
+  const id = event_data['id']
+  if (!(id in _id_to_parse_promise)) {
+    throw Error('Got an invalid parse id. No parse job queued with this id.')
+  }
 
-    const [resolve, reject] = _id_to_parse_promise[id];
-    
-    if (event_data['success'])
-        resolve(JSON.parse(event_data['data']));
-    else
-        reject();
-    
-    delete _id_to_parse_promise[id];
+  const [resolve, reject] = _id_to_parse_promise[id]
+
+  if (event_data['success']) resolve(JSON.parse(event_data['data']))
+  else reject()
+
+  delete _id_to_parse_promise[id]
 }
 
 function parse_project(w, file_ids, file_contents) {
-    const id = "" + Math.floor(Math.random() * 1000000000);
+  const id = '' + Math.floor(Math.random() * 1000000000)
 
-    return new Promise((resolve, reject) => {
-        w.postMessage({
-            action: "parse_project",
-            data: {
-                id,
-                file_ids, 
-                file_contents
-            }
-        });
-
-        _id_to_parse_promise[id] = [resolve, reject];
+  return new Promise((resolve, reject) => {
+    w.postMessage({
+      action: 'parse_project',
+      data: {
+        id,
+        file_ids,
+        file_contents,
+      },
     })
+
+    _id_to_parse_promise[id] = [resolve, reject]
+  })
 }

--- a/binding/wasm/parser_wasm.worker.js
+++ b/binding/wasm/parser_wasm.worker.js
@@ -1,51 +1,49 @@
-self.addEventListener('message', (event) => {
-    const action = event["data"]["action"]
+self.addEventListener('message', event => {
+  const action = event['data']['action']
 
-    if (action == "init") {
-        importScripts("parser_wasm.js")
-        Module.onRuntimeInitialized = send_wasm_loaded;
-    } else if (action == 'parse_project') {
-        const file_ids = new Module.StringList();
-        for (const v of event["data"]["data"]["file_ids"])
-            file_ids.push_back("");
+  if (action == 'init') {
+    importScripts('parser_wasm.js')
+    Module.onRuntimeInitialized = send_wasm_loaded
+  } else if (action == 'parse_project') {
+    const file_ids = new Module.StringList()
+    for (const v of event['data']['data']['file_ids']) file_ids.push_back('')
 
-        const file_contents = new Module.StringList();
-        for (const c of event["data"]["data"]["file_contents"])
-            file_contents.push_back(c);
+    const file_contents = new Module.StringList()
+    for (const c of event['data']['data']['file_contents'])
+      file_contents.push_back(c)
 
-        var res;
-        try {
-            res = Module.parse_project(file_ids, file_contents);
-        } catch (e) {
-            send_parse_project_error(event["data"]["data"]["id"]);
-            return;
-        }
-        send_parse_project_result(res, event["data"]["data"]["id"]);
-    } else {
-        throw Error(`Worker received invalid command "${event['data']}"`)
+    var res
+    try {
+      res = Module.parse_project(file_ids, file_contents)
+    } catch (e) {
+      send_parse_project_error(event['data']['data']['id'])
+      return
     }
-
+    send_parse_project_result(res, event['data']['data']['id'])
+  } else {
+    throw Error(`Worker received invalid command "${event['data']}"`)
+  }
 })
 
 function send_wasm_loaded() {
-    self.postMessage({
-        action: "loaded"
-    });
+  self.postMessage({
+    action: 'loaded',
+  })
 }
 
 function send_parse_project_error(parse_id) {
-    self.postMessage({
-        action: "parse_project_result",
-        success: false,
-        id: parse_id
-    });
+  self.postMessage({
+    action: 'parse_project_result',
+    success: false,
+    id: parse_id,
+  })
 }
 
 function send_parse_project_result(res, parse_id) {
-    self.postMessage({
-        action: "parse_project_result",
-        success: true,
-        data: res,
-        id: parse_id
-    });
+  self.postMessage({
+    action: 'parse_project_result',
+    success: true,
+    data: res,
+    id: parse_id,
+  })
 }

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+cd /libieml/build && \
+    emcmake cmake -DBUILD_WASM:bool=True .. &&\
+    emmake make -j $NB_CORES
+
+ls /libieml/build/binding/wasm/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile_build_wasm
+    volumes:
+      - ./build:/libieml/build


### PR DESCRIPTION
When building wasm from docker it is now possible to get the build files.
It also includes the setup to publish wasm as a npm module.