### PR TITLE
feat: add function version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 
 # set the project name
-project(IEML VERSION 0.1)
+project(IEML VERSION 0.2.0)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 LIST( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
+
+# transfer version to config.h
+configure_file(${CMAKE_SOURCE_DIR}/cmake/config.h.cmake ${CMAKE_SOURCE_DIR}/include/config.h)
+
 
 # set(BUILD_TEST True)
 # set(BUILD_CHECK_ERRORS True)

--- a/binding/wasm/main.cpp
+++ b/binding/wasm/main.cpp
@@ -1,20 +1,26 @@
 #include <iostream>
 #include <emscripten/bind.h>
 
-
 #include "IemlParser.h"
 #include "SyntaxError.h"
 #include "ParserJsonSerializer.h"
+#include "config.h"
 
-
-std::string parse_project(const std::vector<std::string> & file_ids, const std::vector<std::string> & file_contents)
+std::string parse_project(const std::vector<std::string> &file_ids, const std::vector<std::string> &file_contents)
 {
     auto parser = ieml::parser::IEMLParser(file_ids, file_contents);
     parser.parse();
     return ieml::parser::parserToJson(parser).dump();
 }
 
-EMSCRIPTEN_BINDINGS(parser) {
+std::string version()
+{
+    return PROJECT_VERSION;
+}
+
+EMSCRIPTEN_BINDINGS(parser)
+{
     emscripten::register_vector<std::string>("StringList");
     emscripten::function("parse_project", &parse_project);
+    emscripten::function("version", &version);
 }

--- a/binding/wasm/parser_wasm.loader.js
+++ b/binding/wasm/parser_wasm.loader.js
@@ -1,3 +1,5 @@
+// NOT USED, JUST FOR EXAMPLE
+
 export function loadWorker() {
   var worker = null
   if (window && window.Worker) {

--- a/binding/wasm/parser_wasm.worker.js
+++ b/binding/wasm/parser_wasm.worker.js
@@ -1,3 +1,5 @@
+// NOT USED, JUST FOR EXAMPLE
+
 self.addEventListener('message', event => {
   const action = event['data']['action']
 

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -1,0 +1,16 @@
+// https://stackoverflow.com/questions/30027016/cannot-export-cmake-project-version-major-because-it-equals-zero
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define PROJECT "@PROJECT@"
+
+#define PROJECT_VERSION "@PROJECT_VERSION@"
+
+#define PROJECT_VERSION_MAJOR "@PROJECT_VERSION_MAJOR@"
+
+#define PROJECT_VERSION_MINOR "@PROJECT_VERSION_MINOR@"
+
+#define PROJECT_VERSION_PATCH "@PROJECT_VERSION_PATCH@"
+
+#endif

--- a/include/IemlParser.h
+++ b/include/IemlParser.h
@@ -16,59 +16,63 @@
 #include "ast/Program.h"
 #include "structure/path/PathTree.h"
 
-namespace ieml {
-namespace parser {
+namespace ieml
+{
+    namespace parser
+    {
 
+        class IEMLParser
+        {
+        public:
+            class FileParser
+            {
+            public:
+                FileParser(const std::string &file_id, const std::string &input_str, IEMLParserErrorListener *error_manager);
+                ~FileParser();
 
-class IEMLParser {
-public:
-    class FileParser {
-    public:
-        FileParser(const std::string& file_id, const std::string& input_str, IEMLParserErrorListener* error_manager);
-        ~FileParser();
+                void parse();
+                std::shared_ptr<ieml::AST::Program> getProgram() { return ast_; };
 
-        void parse();
-        std::shared_ptr<ieml::AST::Program> getProgram() {return ast_;};
+                FileParser(const FileParser &) = delete;
 
-        FileParser(const FileParser&) = delete;
-    private:
-        antlr4::ANTLRInputStream* input_ = nullptr;
-        ieml_generated::IEMLLexerGrammar* lexer_ = nullptr;
-        ieml_generated::IEMLParserGrammar* parser_ = nullptr;
-        antlr4::CommonTokenStream* tokens_ = nullptr;
+            private:
+                antlr4::ANTLRInputStream *input_ = nullptr;
+                ieml_generated::IEMLLexerGrammar *lexer_ = nullptr;
+                ieml_generated::IEMLParserGrammar *parser_ = nullptr;
+                antlr4::CommonTokenStream *tokens_ = nullptr;
 
-        std::shared_ptr<IEMLGrammarVisitor> visitor_;
-        antlr4::tree::ParseTree* parseTree_ = nullptr;
-        std::shared_ptr<ieml::AST::Program> ast_;
-    };
+                std::shared_ptr<IEMLGrammarVisitor> visitor_;
+                antlr4::tree::ParseTree *parseTree_ = nullptr;
+                std::shared_ptr<ieml::AST::Program> ast_;
+            };
 
+            IEMLParser(const std::vector<std::string> &file_ids,
+                       const std::vector<std::string> &file_contents,
+                       bool error_stdout = false);
 
-    IEMLParser(const std::vector<std::string>& file_ids, 
-               const std::vector<std::string>& file_contents, 
-               bool error_stdout = false);
+            IEMLParser(const std::string &input_str, bool error_stdout = false) : IEMLParser({""}, {input_str}, error_stdout){};
 
-    IEMLParser(const std::string& input_str, bool error_stdout = false) : 
-        IEMLParser({""}, {input_str}, error_stdout) {};
+            void parse();
 
-    void parse();
+            const std::vector<const SyntaxError *> getSyntaxErrors() const { return error_listener_->getSyntaxErrors(); }
+            const std::vector<const SyntaxError *> getSyntaxWarnings() const { return error_listener_->getSyntaxWarnings(); }
+            const IEMLParserErrorListener &getErrorListener() const { return *error_listener_; }
 
-    const std::vector<const SyntaxError*> getSyntaxErrors() const { return error_listener_->getSyntaxErrors(); }
-    const std::vector<const SyntaxError*> getSyntaxWarnings() const { return error_listener_->getSyntaxWarnings(); }
-    const IEMLParserErrorListener& getErrorListener() const { return *error_listener_; }
-    
-    std::shared_ptr<ParserContextManager> getContext() const {return context_;};
+            std::shared_ptr<ParserContextManager> getContext() const { return context_; };
 
-    const std::string& getDefaultFileId() const {
-        return (file_ids_.size() != 0 ? file_ids_[0] : default_file_id);
-    };
-    static const std::string default_file_id;
+            const std::string &getDefaultFileId() const
+            {
+                return (file_ids_.size() != 0 ? file_ids_[0] : default_file_id);
+            };
+            static const std::string default_file_id;
 
-private:
-    std::unordered_map<std::string, std::unique_ptr<FileParser>> file_to_parser_;
-    std::vector<std::string> file_ids_;
+        private:
+            std::unordered_map<std::string, std::unique_ptr<FileParser>> file_to_parser_;
+            std::vector<std::string> file_ids_;
 
-    std::shared_ptr<IEMLParserErrorListener> error_listener_;
-    std::shared_ptr<ParserContextManager> context_;
-};
+            std::shared_ptr<IEMLParserErrorListener> error_listener_;
+            std::shared_ptr<ParserContextManager> context_;
+        };
 
-}}
+    }
+}

--- a/src/IemlParser.cpp
+++ b/src/IemlParser.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "IemlParser.h"
 #include "IEMLGrammarVisitor.h"
 
@@ -5,10 +7,10 @@
 
 using namespace ieml::parser;
 
-
 const std::string IEMLParser::default_file_id = "__default__";
 
-IEMLParser::FileParser::FileParser(const std::string& file_id, const std::string& input_str, IEMLParserErrorListener* error_listener) {
+IEMLParser::FileParser::FileParser(const std::string &file_id, const std::string &input_str, IEMLParserErrorListener *error_listener)
+{
     input_ = new antlr4::ANTLRInputStream(input_str);
 
     visitor_ = std::make_shared<IEMLGrammarVisitor>(file_id, error_listener);
@@ -30,47 +32,50 @@ IEMLParser::FileParser::FileParser(const std::string& file_id, const std::string
     parser_->getInterpreter<atn::ParserATNSimulator>()->setPredictionMode(atn::PredictionMode::SLL);
 }
 
-IEMLParser::FileParser::~FileParser() {
+IEMLParser::FileParser::~FileParser()
+{
     delete input_;
     delete parser_;
     delete tokens_;
     delete lexer_;
 }
 
-void IEMLParser::FileParser::parse() {
-    if (parseTree_ != nullptr) 
+void IEMLParser::FileParser::parse()
+{
+    if (parseTree_ != nullptr)
         return;
 
     parseTree_ = parser_->program();
     ast_ = std::move(visitor_->visit(parseTree_)
-                             .as<IEMLGrammarVisitor::VisitorResult<std::shared_ptr<Program>>>()
-                             .release());
+                         .as<IEMLGrammarVisitor::VisitorResult<std::shared_ptr<Program>>>()
+                         .release());
 }
 
-
-IEMLParser::IEMLParser(const std::vector<std::string>& file_ids, 
-                       const std::vector<std::string>& file_contents, 
-                       bool error_stdout) {
+IEMLParser::IEMLParser(const std::vector<std::string> &file_ids,
+                       const std::vector<std::string> &file_contents,
+                       bool error_stdout)
+{
     file_ids_ = file_ids;
     error_listener_ = std::make_shared<IEMLParserErrorListener>(error_stdout);
 
-    for (size_t i = 0; i < file_ids_.size(); ++i) {
+    for (size_t i = 0; i < file_ids_.size(); ++i)
+    {
         file_to_parser_.insert({file_ids[i], std::make_unique<FileParser>(file_ids[i], file_contents[i], error_listener_.get())});
     }
-
 }
- 
-void IEMLParser::parse() {
-    if (context_ != nullptr) 
+
+void IEMLParser::parse()
+{
+    if (context_ != nullptr)
         return;
 
     context_ = std::make_shared<ParserContextManager>(error_listener_.get());
 
-
-    for (auto file: file_ids_) {
+    for (auto file : file_ids_)
+    {
         auto parser = file_to_parser_.find(file);
         parser->second->parse();
-        
+
         context_->resetLanguage();
         parser->second->getProgram()->check_program(*context_);
     }


### PR DESCRIPTION
Add a new function `version` exported for libieml (only for wasm for now).
This function returns a string containing the version of the parser.

The parser version has also been incremented.