### PR TITLE
fix: compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(IEML VERSION 0.3.0)
-# set(MSVC true)
+
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -43,7 +43,6 @@ if (DEFINED BUILD_TEST OR DEFINED BUILD_PYBIND11 OR DEFINED BUILD_WASM)
 
     if (DEFINED BUILD_TEST)
         message("Building libieml ctest")
-        # set(CMAKE_CXX_FLAGS "-mmacosx-version-min=12.0")
         add_subdirectory(${CMAKE_SOURCE_DIR}/thirdparty/googletest-release-1.11.0)
         # test section
         add_subdirectory(test)

--- a/src/ParserJsonSerializer.cpp
+++ b/src/ParserJsonSerializer.cpp
@@ -133,7 +133,8 @@ nlohmann::json ieml::parser::categoryToJson(ieml::structure::PathTree::Ptr categ
         }
     }
 
-    std::string wordId = category->get_phrase_word()->uid();
+    ieml::structure::Word::Ptr word = category->get_phrase_word();
+    std::string wordId = word != nullptr ? word->uid() : "";
 
     return {
         {"id", category->uid()},


### PR DESCRIPTION
Links are category without `phrase_word`. It was failing the parsing and triggering the errors.