### PR TITLE
Fix a bug on buildFromPath that was not factorizing path with same pathnode

### DIFF
--- a/include/structure/path/PathNode.h
+++ b/include/structure/path/PathNode.h
@@ -48,12 +48,24 @@ public:
     virtual std::shared_ptr<JunctionWord> getJunctionType() const {throw std::invalid_argument("No JunctionWord defined for " +std::string(getPathType()._to_string())+ " path node.");};
 
     virtual std::shared_ptr<AuxiliaryWord> getAuxialiryType() const {throw std::invalid_argument("No AuxiliaryWord defined for " +std::string(getPathType()._to_string())+ " path node.");};
-    virtual const std::set<std::shared_ptr<InflectionWord>>& getInflections() const {throw std::invalid_argument("No InflectionWords defined for " +std::string(getPathType()._to_string())+ " path node.");}; 
+    virtual const std::set<std::shared_ptr<InflectionWord>>& getInflections() const {throw std::invalid_argument("No InflectionWords defined for " +std::string(getPathType()._to_string())+ " path node.");};
     virtual const std::shared_ptr<CategoryWord> getCategoryWord() const {throw std::invalid_argument("No CategoryWord defined for " +std::string(getPathType()._to_string())+ " path node.");};
 
 
     typedef std::set<std::shared_ptr<PathNode>> Set;
     typedef std::vector<std::shared_ptr<PathNode>> Vector;
+
+
+    struct HashFunctor {
+        size_t operator()(const ieml::structure::PathNode::Ptr& a) const;
+    };
+
+    struct EqualityFunctor {
+        bool operator()(const ieml::structure::PathNode::Ptr& a, const ieml::structure::PathNode::Ptr& b) const {
+            return *a == *b;
+        }
+    };
+
 
 private:
     virtual int comp(const PathNode& a) const = 0;
@@ -123,7 +135,7 @@ class JunctionPathNode : public PathNode {
 public:
     JunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : junction_type_(junction_type) {}
     virtual std::string to_string() const override;
-    
+
     virtual std::shared_ptr<JunctionWord> getJunctionType() const override {return junction_type_;};
     virtual const std::set<std::shared_ptr<Word>> getWords() const override {return {junction_type_};};
 
@@ -239,7 +251,7 @@ public:
         return std::set<std::shared_ptr<Word>>(inflections_.begin(), inflections_.end());
     };
 
-    virtual const std::set<std::shared_ptr<InflectionWord>>& getInflections() const override {return inflections_;}; 
+    virtual const std::set<std::shared_ptr<InflectionWord>>& getInflections() const override {return inflections_;};
 
 private:
     virtual int comp(const PathNode& a) const override {

--- a/src/structure/path/PathNode.cpp
+++ b/src/structure/path/PathNode.cpp
@@ -195,7 +195,7 @@ std::string InflectionPathNode::to_string() const {
     std::ostringstream os;
     for (auto& inflection: inflections_)
         os << "~" << inflection->to_string();
-    
+
     return os.str();
 }
 
@@ -205,4 +205,9 @@ bool WordPathNode::accept_next(__attribute__((unused)) const PathNode& next) con
 PathType WordPathNode::getPathType() const {return PathType::WORD;}
 std::string WordPathNode::to_string() const {
     return word_->to_string();
+}
+
+
+size_t PathNode::HashFunctor::operator()(const ieml::structure::PathNode::Ptr& a) const {
+    return std::hash<ieml::structure::PathNode>()(*a);
 }

--- a/test/grammar/test_paradigm.cpp
+++ b/test/grammar/test_paradigm.cpp
@@ -35,7 +35,7 @@ TEST(ieml_grammar_test_case, paradigm_definition) {
 };
 
 TEST(ieml_grammar_test_case, paradigm_definition_2d) {
-    PARSE_NO_ERRORS(R"(@word "a.". @word "b.". 
+    PARSE_NO_ERRORS(R"(@word "a.". @word "b.".
                        @node en:invariant (0 #"a.").
                        @node en:node0 (0 #"a.", 1 #"a.", 2 #"a.").
                        @node en:node1 (0 #"a.", 1 #"b.", 2 #"a.").
@@ -59,7 +59,7 @@ TEST(ieml_grammar_test_case, paradigm_definition_2d) {
     ASSERT_NE(node2, nullptr);
     ASSERT_NE(node3, nullptr);
 
-    ASSERT_EQ(ieml::structure::PathTree::singular_sequences(paradigm), 
+    ASSERT_EQ(ieml::structure::PathTree::singular_sequences(paradigm),
               ieml::structure::PathTree::Vector({node0, node1, node2, node3}));
 };
 
@@ -83,7 +83,7 @@ TEST(ieml_grammar_test_case, paradigm_register) {
 
 
 TEST(ieml_grammar_test_case, paradigm_dimension_definition) {
-    PARSE_NO_ERRORS(R"(@word "a.". @word "b.". 
+    PARSE_NO_ERRORS(R"(@word "a.". @word "b.".
                        @node en:invariant (0 #"a.").
                        @node en:node0 (0 #"a.", 1 #"a.", 2 #"a.").
                        @node en:node1 (0 #"a.", 1 #"a.", 2 #"b.").
@@ -114,4 +114,13 @@ TEST(ieml_grammar_test_case, paradigm_dimension_definition) {
     ASSERT_EQ(table->at(0, {0, 1, 0}), node1);
     ASSERT_EQ(table->at(0, {1, 0, 0}), node2);
     ASSERT_EQ(table->at(0, {1, 1, 0}), node3);
+}
+
+
+TEST(ieml_grammar_test_case, no_regression_missing_invariant) {
+    PARSE_NO_ERRORS(R"(@word "a.". @word "b.".
+                       @node en:node0 (0 #"a.").
+                       @node en:node1 (0 #"a.", 1 #"a.").
+                       @node en:invariant (0 #node0, 1 #node1).
+                       @paranode en:paranode 1d:/#/4 (0 #node0, 1 #node1, 4 {#"b.";#"a."}).)");
 }

--- a/test/structure/test_path.cpp
+++ b/test/structure/test_path.cpp
@@ -37,7 +37,7 @@ TEST(ieml_structure_test_case, path_serialization) {
         auto path = reg.get_or_create(std::make_shared<WordPathNode>(std::make_shared<CategoryWord>(ieml::testing::parse_script(&sreg, "wa."))));
         auto path1 = reg.get_or_create(std::make_shared<InflectionPathNode>(plr), {path});
         auto path2 = reg.get_or_create(std::make_shared<RoleNumberPathNode>(RoleType::ROOT), {path1});
-        
+
         EXPECT_TRUE(path2->is_valid()) << "Invalid argument should not have been thrown on path.";
         EXPECT_EQ(path2->to_string_path(), R"(/0/~"we."/"wa.")") << "Invalid path serialization";
     }
@@ -69,7 +69,7 @@ TEST(ieml_structure_test_case, path_serialization) {
         EXPECT_TRUE(path4->is_valid()) << "Invalid argument should not have been thrown on path.";
         EXPECT_EQ(path4->to_string_path(), R"(/0/*"wa."/&"E:E:A:."/[0]/"wa.")") << "Invalid path serialization";
     }
-    
+
 }
 
 TEST(ieml_structure_test_case, path_from_string) {
@@ -128,7 +128,7 @@ TEST(ieml_structure_test_case, path_tree_comparison) {
     EXPECT_LE(*tree1, *tree3);
     EXPECT_LE(*tree1, *tree2);
     EXPECT_LT(*tree1, *tree2);
-    
+
     EXPECT_GE(*tree1, *tree3);
     EXPECT_GE(*tree2, *tree1);
     EXPECT_GT(*tree2, *tree1);
@@ -174,12 +174,12 @@ TEST(ieml_structure_test_case, path_tree_building_error) {
     }
     {
 
-        auto a = reg.get_or_create(std::make_shared<RoleNumberPathNode>(RoleType::ROOT), 
+        auto a = reg.get_or_create(std::make_shared<RoleNumberPathNode>(RoleType::ROOT),
             {reg.get_or_create(std::make_shared<AuxiliaryPathNode>(std::make_shared<AuxiliaryWord>(ieml::testing::parse_script(&sreg, "wa."), RoleType::ROOT)))});
 
-        auto b = reg.get_or_create(std::make_shared<RoleNumberPathNode>(RoleType::ROOT), 
+        auto b = reg.get_or_create(std::make_shared<RoleNumberPathNode>(RoleType::ROOT),
             {reg.get_or_create(std::make_shared<WordPathNode>(std::make_shared<CategoryWord>(ieml::testing::parse_script(&sreg, "wa."))))});
-        
+
         EXPECT_THROW(reg.buildFromPaths({a, b}), std::invalid_argument);
     }
 
@@ -210,7 +210,7 @@ TEST(ieml_structure_test_case, path_tree_register) {
         EXPECT_EQ(*container->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0], *included->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]);
         // pointer
         EXPECT_EQ(container->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0], included->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]);
- 
+
         // assert that container['/#/0/#/0'] == included['/#/0']
         // value
         EXPECT_EQ(*container->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0]->getChildrenAsVector()[0], *included->getChildrenAsVector()[0]->getChildrenAsVector()[0]);
@@ -235,7 +235,7 @@ TEST(ieml_structure_test_case, path_tree_register) {
 TEST(ieml_structure_test_case, path_tree_invariant) {
     PARSE_NO_ERRORS(R"(@word "wa.". @word "a.". @word "b.". @node en:root (0 #"wa."). @node en:node0 (0 #"wa.", 1 #"a."). @node en:node1 (0 #"wa.", 1 #"b.").)");
     auto context = parser.getContext();
-    
+
     auto root = context->getCategoryRegister().resolve_category(LanguageString(LanguageType::EN, "root"));
     auto node0 = context->getCategoryRegister().resolve_category(LanguageString(LanguageType::EN, "node0"));
     auto node1 = context->getCategoryRegister().resolve_category(LanguageString(LanguageType::EN, "node1"));
@@ -246,7 +246,7 @@ TEST(ieml_structure_test_case, path_tree_invariant) {
 
     auto reg = context->getPathTreeRegister();
 
-    auto paradigm = reg.get_or_create(std::make_shared<ParadigmPathNode>(), 
+    auto paradigm = reg.get_or_create(std::make_shared<ParadigmPathNode>(),
             {reg.get_or_create(std::make_shared<ParadigmIndexPathNode>(0), {node0}),
              reg.get_or_create(std::make_shared<ParadigmIndexPathNode>(1), {node1})});
 
@@ -260,7 +260,7 @@ TEST(ieml_structure_test_case, path_tree_invariant) {
     ASSERT_NE(invariant, nullptr);
 
     EXPECT_EQ(invariant, root);
-}   
+}
 
 TEST(ieml_structure_test_case, path_prefix) {
     ieml::parser::IEMLParserErrorListener error_listener;
@@ -270,7 +270,7 @@ TEST(ieml_structure_test_case, path_prefix) {
     wregister.declare_script(script, WordType::CATEGORY);
     wregister.define_word(std::make_shared<CategoryWord>(script));
 
-    auto p0 = ieml::parser::parsePath(ctx, R"(/#/0/"wa.")", true);   
+    auto p0 = ieml::parser::parsePath(ctx, R"(/#/0/"wa.")", true);
     auto p1 = ieml::parser::parsePath(ctx, R"(/#/1/"wa.")", true);
 
     ASSERT_NE(p0, nullptr);
@@ -278,10 +278,34 @@ TEST(ieml_structure_test_case, path_prefix) {
 
     EXPECT_FALSE(p0->is_prefix(p1));
 
-    p0 = ieml::parser::parsePath(ctx, R"(/#/0)", true);   
+    p0 = ieml::parser::parsePath(ctx, R"(/#/0)", true);
     p1 = ieml::parser::parsePath(ctx, R"(/#/1/"wa.")", true);
 
     EXPECT_FALSE(p0->is_prefix(p1));
+}
+
+TEST(ieml_structure_test_case, path_factorize_sub_phrase) {
+    ieml::parser::IEMLParserErrorListener error_listener;
+    ieml::parser::ParserContextManager ctx(&error_listener);
+    auto& wregister = ctx.getWordRegister();
+
+    auto script = ieml::testing::parse_script(&ctx.getScriptRegister(), "a.");
+    wregister.declare_script(script, WordType::CATEGORY);
+    wregister.define_word(std::make_shared<CategoryWord>(script));
+
+    auto p0 = ieml::parser::parsePath(ctx, R"(/#/0/#/0/"a.")", true);
+    auto p1 = ieml::parser::parsePath(ctx, R"(/#/1/#/0/"a.")", true);
+    auto p2 = ieml::parser::parsePath(ctx, R"(/#/1/#/1/"a.")", true);
+
+    ASSERT_NE(p0, nullptr);
+    ASSERT_NE(p1, nullptr);
+    ASSERT_NE(p2, nullptr);
+
+    PathTree::Register reg;
+
+    auto pt = reg.buildFromPaths({p0, p1, p2});
+
+    ASSERT_EQ(pt->getChildren().size(), 2); // two children of phrase : role 0 and role 1. Role 1 is factorized
 }
 
 TEST(ieml_structure_test_case, path_is_contained) {
@@ -292,7 +316,7 @@ TEST(ieml_structure_test_case, path_is_contained) {
     wregister.declare_script(script, WordType::CATEGORY);
     wregister.define_word(std::make_shared<CategoryWord>(script));
 
-    auto p0 = ieml::parser::parsePath(ctx, R"(/#/0/"wa.")", true);   
+    auto p0 = ieml::parser::parsePath(ctx, R"(/#/0/"wa.")", true);
     auto p1 = ieml::parser::parsePath(ctx, R"(/#/1/"wa.")", true);
     ASSERT_NE(p0, nullptr);
     ASSERT_NE(p1, nullptr);
@@ -300,7 +324,7 @@ TEST(ieml_structure_test_case, path_is_contained) {
     EXPECT_FALSE(p0->is_contained(p1));
 
 
-    p0 = ieml::parser::parsePath(ctx, R"(/#/0)", true);   
+    p0 = ieml::parser::parsePath(ctx, R"(/#/0)", true);
     p1 = ieml::parser::parsePath(ctx, R"(/#/1/"wa.")", true);
 
     EXPECT_FALSE(p0->is_contained(p1));


### PR DESCRIPTION
This is addressing "Cannot define paradigm when invariant is not defined".
The issue was a map using pointer as key instead of its referenced value.

I have added test for the bug.