### PR TITLE
[feature] add != operator in word condition expressions

### DIFF
--- a/include/IEMLGrammarVisitor.h
+++ b/include/IEMLGrammarVisitor.h
@@ -163,7 +163,8 @@ public:
   virtual antlrcpp::Any visitWord_condition_function__word_condition(IEMLParserGrammar::Word_condition_function__word_conditionContext *context) override;
   virtual antlrcpp::Any visitWord_condition_function__parenthesis(IEMLParserGrammar::Word_condition_function__parenthesisContext *context) override;
   virtual antlrcpp::Any visitWord_condition_function__operator(IEMLParserGrammar::Word_condition_function__operatorContext *context) override;
-  virtual antlrcpp::Any visitWord_condition(IEMLParserGrammar::Word_conditionContext *context) override;
+  virtual antlrcpp::Any visitWord_condition__equal(IEMLParserGrammar::Word_condition__equalContext *context) override;
+  virtual antlrcpp::Any visitWord_condition__not_equal(IEMLParserGrammar::Word_condition__not_equalContext *context) override;
   
   virtual antlrcpp::Any visitWord_accessor__variable(IEMLParserGrammar::Word_accessor__variableContext *context) override;
   virtual antlrcpp::Any visitWord_accessor__literal(IEMLParserGrammar::Word_accessor__literalContext *context) override;

--- a/include/ast/function/WordFunctionCondition.h
+++ b/include/ast/function/WordFunctionCondition.h
@@ -3,118 +3,182 @@
 #include "ast/interfaces/AST.h"
 #include "ast/function/WordAccessor.h"
 
+namespace ieml::AST
+{
 
-namespace ieml::AST {
+    /**
+     * @brief Abstract class representing comparison function between two Word accessor, left and right.
+     *        The two word accessor are assumed to yield same layer scripts.
+     *        This class is subclassed for script binary operators (==, !=, etc...)
+     */
+    class WordFunctionCondition : public virtual AST
+    {
+    public:
+        IEML_DECLARE_PTR_TYPE_AST(WordFunctionCondition)
 
-class WordFunctionCondition : public virtual AST {
-public:
-    IEML_DECLARE_PTR_TYPE_AST(WordFunctionCondition)
+        WordFunctionCondition(CharRange::Ptr &&char_range,
+                              WordAccessor::Ptr &&left,
+                              WordAccessor::Ptr &&right) : AST(std::move(char_range)),
+                                                           left_(std::move(left)),
+                                                           right_(std::move(right)) {}
 
-    WordFunctionCondition(CharRange::Ptr&& char_range,
-                          WordAccessor::Ptr&& left,
-                          WordAccessor::Ptr&& right) :
-        AST(std::move(char_range)),
-        left_(std::move(left)),
-        right_(std::move(right)) {}
+        /**
+         * @brief Instanciate a ieml::structure::WordCondition subclass corresponding to this WordFunctionCondition subclass.
+         *
+         * @param left
+         * @param right
+         * @return ieml::structure::WordCondition::Ptr
+         */
+        virtual ieml::structure::WordCondition::Ptr build_word_condition(
+            ieml::structure::WordAccessor::Ptr &&left,
+            ieml::structure::WordAccessor::Ptr &&right) const = 0;
 
-    virtual std::string to_string() const override {return left_->to_string() + " == " + right_->to_string();}
+        virtual std::string to_string_operator() const = 0;
 
-    std::optional<ieml::structure::EqualWordCondition::Ptr> check_word_condition(ieml::parser::ParserContextManager& ctx, 
-                                                                                 const ieml::structure::Link::Ptr& link,
-                                                                                 const ieml::structure::WordDomain& domain) const {
-        const auto left = left_->check_accessor(ctx, link, domain);
-        const auto right = right_->check_accessor(ctx, link, domain);
-        if (!left || !right) return {};
+        virtual std::string to_string() const override { return left_->to_string() + " " + to_string_operator() + " " + right_->to_string(); }
 
-        size_t l_layer_comp = 0;
-        size_t r_layer_comp = 0;
-
-        ieml::structure::WordAccessor::Ptr l_accessor;
-        ieml::structure::WordAccessor::Ptr r_accessor;
-
-        if (left->type_ == WordAccessor::WordAccessorArgs::Type::LITERAL) {
-            l_layer_comp = left->script_->get_layer();
-            l_accessor = std::make_shared<ieml::structure::LiteralWordAccessor>(
-                left->script_
-            );
-        } else {
-            const auto l_dom = domain.find(left->name_);
-            if (l_dom == domain.end()) {
-                ctx.getErrorManager().visitorError(
-                    left_->getCharRange(),
-                    "Variable not defined : " + left->name_ + "."
-                );
+        std::optional<ieml::structure::EqualWordCondition::Ptr> check_word_condition(ieml::parser::ParserContextManager &ctx,
+                                                                                     const ieml::structure::Link::Ptr &link,
+                                                                                     const ieml::structure::WordDomain &domain) const
+        {
+            const auto left = left_->check_accessor(ctx, link, domain);
+            const auto right = right_->check_accessor(ctx, link, domain);
+            if (!left || !right)
                 return {};
+
+            size_t l_layer_comp = 0;
+            size_t r_layer_comp = 0;
+
+            ieml::structure::WordAccessor::Ptr l_accessor;
+            ieml::structure::WordAccessor::Ptr r_accessor;
+
+            if (left->type_ == WordAccessor::WordAccessorArgs::Type::LITERAL)
+            {
+                l_layer_comp = left->script_->get_layer();
+                l_accessor = std::make_shared<ieml::structure::LiteralWordAccessor>(
+                    left->script_);
+            }
+            else
+            {
+                const auto l_dom = domain.find(left->name_);
+                if (l_dom == domain.end())
+                {
+                    ctx.getErrorManager().visitorError(
+                        left_->getCharRange(),
+                        "Variable not defined : " + left->name_ + ".");
+                    return {};
+                }
+
+                const auto l_layer = l_dom->second->get_layer();
+                if (l_layer < left->accessors_.size())
+                {
+                    ctx.getErrorManager().visitorError(
+                        left_->getCharRange(),
+                        "Left operand has a negative layer.");
+                    return {};
+                }
+
+                l_layer_comp = l_layer - left->accessors_.size();
+
+                l_accessor = std::make_shared<ieml::structure::VariableWordAccessor>(
+                    left->name_,
+                    l_layer,
+                    left->accessors_);
             }
 
-            const auto l_layer = l_dom->second->get_layer();
-            if (l_layer < left->accessors_.size()) {
-                ctx.getErrorManager().visitorError(
-                    left_->getCharRange(),
-                    "Left operand has a negative layer."
-                );
-                return {};
+            if (right->type_ == WordAccessor::WordAccessorArgs::Type::LITERAL)
+            {
+                r_layer_comp = right->script_->get_layer();
+                r_accessor = std::make_shared<ieml::structure::LiteralWordAccessor>(
+                    right->script_);
+            }
+            else
+            {
+                const auto r_dom = domain.find(right->name_);
+                if (r_dom == domain.end())
+                {
+                    ctx.getErrorManager().visitorError(
+                        right_->getCharRange(),
+                        "Variable not defined : " + right->name_ + ".");
+                    return {};
+                }
+
+                const auto r_layer = r_dom->second->get_layer();
+                if (r_layer < right->accessors_.size())
+                {
+                    ctx.getErrorManager().visitorError(
+                        right_->getCharRange(),
+                        "Right operand has a negative layer.");
+                    return {};
+                }
+                r_layer_comp = r_layer - right->accessors_.size();
+
+                r_accessor = std::make_shared<ieml::structure::VariableWordAccessor>(
+                    right->name_,
+                    r_layer,
+                    right->accessors_);
             }
 
-            l_layer_comp = l_layer - left->accessors_.size();
-
-            l_accessor = std::make_shared<ieml::structure::VariableWordAccessor>(
-                left->name_,
-                l_layer,
-                left->accessors_
-            );
-        }
-
-        if (right->type_ == WordAccessor::WordAccessorArgs::Type::LITERAL) {
-            r_layer_comp = right->script_->get_layer();
-            r_accessor = std::make_shared<ieml::structure::LiteralWordAccessor>(
-                right->script_
-            );
-        } else {
-            const auto r_dom = domain.find(right->name_);
-            if (r_dom == domain.end()) {
+            if (l_layer_comp != r_layer_comp)
+            {
                 ctx.getErrorManager().visitorError(
                     right_->getCharRange(),
-                    "Variable not defined : " + right->name_ + "."
-                );
+                    "Right operand has a different layer than the left operand.");
                 return {};
             }
 
-            const auto r_layer = r_dom->second->get_layer();
-            if (r_layer < right->accessors_.size()) {
-                ctx.getErrorManager().visitorError(
-                    right_->getCharRange(),
-                    "Right operand has a negative layer."
-                );
-                return {};
-            }
-            r_layer_comp = r_layer - right->accessors_.size();
-            
-            r_accessor = std::make_shared<ieml::structure::VariableWordAccessor>(
-                right->name_,
-                r_layer,
-                right->accessors_
-            );
-
+            return build_word_condition(
+                std::move(l_accessor),
+                std::move(r_accessor));
         }
 
-        if (l_layer_comp != r_layer_comp) {
-            ctx.getErrorManager().visitorError(
-                right_->getCharRange(),
-                "Right operand has a different layer than the left operand."
-            );
-            return {};
+    private:
+        const WordAccessor::Ptr left_;
+        const WordAccessor::Ptr right_;
+    };
+
+    class WordFunctionConditionEquality : public virtual AST, public WordFunctionCondition
+    {
+    public:
+        IEML_DECLARE_PTR_TYPE_AST(WordFunctionConditionEquality)
+
+        WordFunctionConditionEquality(CharRange::Ptr &&char_range,
+                                      WordAccessor::Ptr &&left,
+                                      WordAccessor::Ptr &&right) : AST(std::move(char_range)),
+                                                                   WordFunctionCondition(nullptr, std::move(left), std::move(right)) {}
+
+        virtual ieml::structure::WordCondition::Ptr build_word_condition(
+            ieml::structure::WordAccessor::Ptr &&left,
+            ieml::structure::WordAccessor::Ptr &&right) const override
+        {
+            return std::make_shared<ieml::structure::EqualWordCondition>(
+                std::move(left),
+                std::move(right));
         }
 
-        return std::make_shared<ieml::structure::EqualWordCondition>(
-            std::move(l_accessor),
-            std::move(r_accessor)
-        );
-    }
+        virtual std::string to_string_operator() const override { return "=="; }
+    };
 
-private:
-    const WordAccessor::Ptr left_;
-    const WordAccessor::Ptr right_;
-};
+    class WordFunctionConditionInequality : public virtual AST, public WordFunctionCondition
+    {
+    public:
+        IEML_DECLARE_PTR_TYPE_AST(WordFunctionConditionInequality)
+
+        WordFunctionConditionInequality(CharRange::Ptr &&char_range,
+                                        WordAccessor::Ptr &&left,
+                                        WordAccessor::Ptr &&right) : AST(std::move(char_range)),
+                                                                     WordFunctionCondition(nullptr, std::move(left), std::move(right)) {}
+
+        virtual ieml::structure::WordCondition::Ptr build_word_condition(
+            ieml::structure::WordAccessor::Ptr &&left,
+            ieml::structure::WordAccessor::Ptr &&right) const override
+        {
+            return std::make_shared<ieml::structure::NotEqualWordCondition>(
+                std::move(left),
+                std::move(right));
+        }
+
+        virtual std::string to_string_operator() const override { return "!="; }
+    };
 
 }

--- a/include/structure/link/function/WordCondition.h
+++ b/include/structure/link/function/WordCondition.h
@@ -10,180 +10,218 @@
 #include <string>
 #include <vector>
 
+namespace ieml::structure
+{
 
-namespace ieml::structure {
+    class WordCondition
+    {
+    public:
+        IEML_DECLARE_PTR_TYPE_STRUCTURE(WordCondition)
 
-class WordCondition {
-public:
-    IEML_DECLARE_PTR_TYPE_STRUCTURE(WordCondition)
+        typedef std::unordered_map<std::string, Word::Ptr> VariableValuation;
 
-    typedef std::unordered_map<std::string, Word::Ptr> VariableValuation;
+        virtual bool evaluate(ScriptRegister &sreg, const VariableValuation &valuation) const = 0;
 
-    virtual bool evaluate(ScriptRegister& sreg, const VariableValuation& valuation) const = 0;
-
-    virtual std::unordered_set<std::string> getVariableNameSet() const = 0;
-};
-
-
-class BooleanWordCondition : public WordCondition {
-public:
-    BooleanWordCondition(const WordCondition::Ptr& left, const WordCondition::Ptr& right, AST::BooleanWordFunctionConditionExprOperatorType type) :
-        left_(left),
-        right_(right),
-        type_(type) {}
-
-    virtual bool evaluate(ScriptRegister& sreg, const VariableValuation& valuation) const override {
-        const auto v_l = left_->evaluate(sreg, valuation);
-        const auto v_r = right_->evaluate(sreg, valuation);
-
-        switch (type_) {
-        case +AST::BooleanWordFunctionConditionExprOperatorType::AND:
-            return v_l && v_r;
-        case +AST::BooleanWordFunctionConditionExprOperatorType::OR:
-            return v_l || v_r;
-        default:
-            throw "INVALID boolean word condition";
-        }
+        virtual std::unordered_set<std::string> getVariableNameSet() const = 0;
     };
 
-    virtual std::unordered_set<std::string> getVariableNameSet() const override {
-        auto l_res = left_->getVariableNameSet();
-        const auto r_res = right_->getVariableNameSet();
-        l_res.insert(r_res.begin(), r_res.end());
-        return l_res;
-    }
+    class BooleanWordCondition : public WordCondition
+    {
+    public:
+        BooleanWordCondition(const WordCondition::Ptr &left, const WordCondition::Ptr &right, AST::BooleanWordFunctionConditionExprOperatorType type) : left_(left),
+                                                                                                                                                        right_(right),
+                                                                                                                                                        type_(type) {}
 
-private:
-    const WordCondition::Ptr left_;
-    const WordCondition::Ptr right_;
-    const AST::BooleanWordFunctionConditionExprOperatorType type_;
+        virtual bool evaluate(ScriptRegister &sreg, const VariableValuation &valuation) const override
+        {
+            const auto v_l = left_->evaluate(sreg, valuation);
+            const auto v_r = right_->evaluate(sreg, valuation);
 
-};
-
-
-class WordAccessor {
-public:
-
-    enum Type {VARIABLE, LITERAL};
-
-    IEML_DECLARE_PTR_TYPE_STRUCTURE(WordAccessor)
-
-    virtual Script::Ptr access(ScriptRegister& sreg, const WordCondition::VariableValuation& valuation) const = 0;
-
-    virtual Type getType() const = 0;
-};
-
-class VariableWordAccessor : public WordAccessor {
-public:
-    IEML_DECLARE_PTR_TYPE_STRUCTURE(VariableWordAccessor)
-
-
-    VariableWordAccessor(const std::string& variable_name,
-                         size_t source_layer,
-                         const std::vector<AST::WordAccessorType>& accessors) :
-        variable_name_(variable_name),
-        accessors_(accessors),
-        source_layer_(source_layer),
-        target_layer_(source_layer - accessors_.size()) {}
-
-    virtual Type getType() const override {return Type::VARIABLE;}
-
-    virtual Script::Ptr access(ScriptRegister& sreg, const WordCondition::VariableValuation& valuation) const override {
-        Script::Ptr s = valuation.find(variable_name_)->second->getScript();
-    
-        if (s->get_type() == +ScriptType::PRIMITIVE) {
-            // source_layer_ == target_layer_ == 0
-            return s;
-        }
-        if (s->get_type() != +ScriptType::MULTIPLICATION) {
-            throw "Variable has to be a multiplicative script";
-        }
-
-        MultiplicativeScript::Ptr curr = dynamic_cast<MultiplicativeScript::Ptr>(s);
-
-        for (auto a : accessors_) {
-            Script::Ptr script;
-            switch (a) {
-            case +AST::WordAccessorType::SUBSTANCE:
-                script = curr->getSubstance();
-                break;
-            case +AST::WordAccessorType::ATTRIBUTE:
-                script = curr->getAttribute();
-                break;
-            case +AST::WordAccessorType::MODE:
-                script = curr->getMode();
-                break;
+            switch (type_)
+            {
+            case +AST::BooleanWordFunctionConditionExprOperatorType::AND:
+                return v_l && v_r;
+            case +AST::BooleanWordFunctionConditionExprOperatorType::OR:
+                return v_l || v_r;
             default:
-                throw "invalid word accessor type";
+                throw "INVALID boolean word condition";
+            }
+        };
+
+        virtual std::unordered_set<std::string> getVariableNameSet() const override
+        {
+            auto l_res = left_->getVariableNameSet();
+            const auto r_res = right_->getVariableNameSet();
+            l_res.insert(r_res.begin(), r_res.end());
+            return l_res;
+        }
+
+    private:
+        const WordCondition::Ptr left_;
+        const WordCondition::Ptr right_;
+        const AST::BooleanWordFunctionConditionExprOperatorType type_;
+    };
+
+    class WordAccessor
+    {
+    public:
+        enum Type
+        {
+            VARIABLE,
+            LITERAL
+        };
+
+        IEML_DECLARE_PTR_TYPE_STRUCTURE(WordAccessor)
+
+        virtual Script::Ptr access(ScriptRegister &sreg, const WordCondition::VariableValuation &valuation) const = 0;
+
+        virtual Type getType() const = 0;
+    };
+
+    class VariableWordAccessor : public WordAccessor
+    {
+    public:
+        IEML_DECLARE_PTR_TYPE_STRUCTURE(VariableWordAccessor)
+
+        VariableWordAccessor(const std::string &variable_name,
+                             size_t source_layer,
+                             const std::vector<AST::WordAccessorType> &accessors) : variable_name_(variable_name),
+                                                                                    accessors_(accessors),
+                                                                                    source_layer_(source_layer),
+                                                                                    target_layer_(source_layer - accessors_.size()) {}
+
+        virtual Type getType() const override { return Type::VARIABLE; }
+
+        virtual Script::Ptr access(ScriptRegister &sreg, const WordCondition::VariableValuation &valuation) const override
+        {
+            Script::Ptr s = valuation.find(variable_name_)->second->getScript();
+
+            if (s->get_type() == +ScriptType::PRIMITIVE)
+            {
+                // source_layer_ == target_layer_ == 0
+                return s;
+            }
+            if (s->get_type() != +ScriptType::MULTIPLICATION)
+            {
+                throw "Variable has to be a multiplicative script";
             }
 
-            if (script->is_nullscript())
-                return sreg.get_nullscript(target_layer_);
+            MultiplicativeScript::Ptr curr = dynamic_cast<MultiplicativeScript::Ptr>(s);
 
-            if (script->get_type() == +ScriptType::PRIMITIVE)
-                return script;
+            for (auto a : accessors_)
+            {
+                Script::Ptr script;
+                switch (a)
+                {
+                case +AST::WordAccessorType::SUBSTANCE:
+                    script = curr->getSubstance();
+                    break;
+                case +AST::WordAccessorType::ATTRIBUTE:
+                    script = curr->getAttribute();
+                    break;
+                case +AST::WordAccessorType::MODE:
+                    script = curr->getMode();
+                    break;
+                default:
+                    throw "invalid word accessor type";
+                }
 
-            curr = dynamic_cast<MultiplicativeScript::Ptr>(script);
+                if (script->is_nullscript())
+                    return sreg.get_nullscript(target_layer_);
+
+                if (script->get_type() == +ScriptType::PRIMITIVE)
+                    return script;
+
+                curr = dynamic_cast<MultiplicativeScript::Ptr>(script);
+            }
+
+            return curr;
         }
 
-        return curr;
-    }
+        std::string getVariableName() const
+        {
+            return variable_name_;
+        };
 
-    std::string getVariableName() const {
-        return variable_name_;
+    private:
+        const std::string variable_name_;
+        const std::vector<AST::WordAccessorType> accessors_;
+
+        const size_t source_layer_;
+        const size_t target_layer_;
     };
 
-private:
-    const std::string variable_name_;
-    const std::vector<AST::WordAccessorType> accessors_;
+    class LiteralWordAccessor : public WordAccessor
+    {
+    public:
+        LiteralWordAccessor(Script::Ptr script) : script_(script) {}
 
-    const size_t source_layer_;
-    const size_t target_layer_;
+        virtual Type getType() const override { return Type::LITERAL; }
 
-};
-
-class LiteralWordAccessor : public WordAccessor {
-public:
-    LiteralWordAccessor(Script::Ptr script) : script_(script) {}
-
-    virtual Type getType() const override {return Type::LITERAL;}
-
-    virtual Script::Ptr access(ScriptRegister&, const WordCondition::VariableValuation&) const override {
-        return script_;
-    }
-
-private:
-    const Script::Ptr script_;
-};
-
-class EqualWordCondition : public WordCondition {
-public:
-    EqualWordCondition(WordAccessor::Ptr&& left, WordAccessor::Ptr&& right) :
-        left_(std::move(left)),
-        right_(std::move(right)) {}
-
-    virtual bool evaluate(ScriptRegister& sreg, const VariableValuation& valuation) const override {
-        const auto v_l = left_->access(sreg, valuation);
-        const auto v_r = right_->access(sreg, valuation);
-        return v_l == v_r;
-    };
-
-    virtual std::unordered_set<std::string> getVariableNameSet() const override {
-        std::unordered_set<std::string> res;
-        if (left_->getType() == WordAccessor::Type::VARIABLE) {
-            res.insert(std::dynamic_pointer_cast<VariableWordAccessor>(left_)->getVariableName());
-        }
-        if (right_->getType() == WordAccessor::Type::VARIABLE) {
-            res.insert(std::dynamic_pointer_cast<VariableWordAccessor>(right_)->getVariableName());
+        virtual Script::Ptr access(ScriptRegister &, const WordCondition::VariableValuation &) const override
+        {
+            return script_;
         }
 
-        return res;
+    private:
+        const Script::Ptr script_;
     };
 
-private:
-    const WordAccessor::Ptr left_;
-    const WordAccessor::Ptr right_;
+    class BinaryOperatorWordCondition : public WordCondition
+    {
+    public:
+        BinaryOperatorWordCondition(WordAccessor::Ptr &&left, WordAccessor::Ptr &&right) : left_(std::move(left)),
+                                                                                           right_(std::move(right)) {}
 
-};
+        virtual bool binary_operator_evaluate(const ieml::structure::Script::Ptr &left, const ieml::structure::Script::Ptr &right) const = 0;
+
+        virtual bool evaluate(ScriptRegister &sreg, const VariableValuation &valuation) const override
+        {
+            const auto v_l = left_->access(sreg, valuation);
+            const auto v_r = right_->access(sreg, valuation);
+            return binary_operator_evaluate(v_l, v_r);
+        };
+
+        virtual std::unordered_set<std::string> getVariableNameSet() const override
+        {
+            std::unordered_set<std::string> res;
+            if (left_->getType() == WordAccessor::Type::VARIABLE)
+            {
+                res.insert(std::dynamic_pointer_cast<VariableWordAccessor>(left_)->getVariableName());
+            }
+            if (right_->getType() == WordAccessor::Type::VARIABLE)
+            {
+                res.insert(std::dynamic_pointer_cast<VariableWordAccessor>(right_)->getVariableName());
+            }
+
+            return res;
+        };
+
+    private:
+        const WordAccessor::Ptr left_;
+        const WordAccessor::Ptr right_;
+    };
+
+    class EqualWordCondition : public BinaryOperatorWordCondition
+    {
+    public:
+        EqualWordCondition(WordAccessor::Ptr &&left, WordAccessor::Ptr &&right) : BinaryOperatorWordCondition(std::move(left), std::move(right)) {}
+
+        virtual bool binary_operator_evaluate(const ieml::structure::Script::Ptr &left, const ieml::structure::Script::Ptr &right) const override
+        {
+            return left == right;
+        };
+    };
+
+    class NotEqualWordCondition : public BinaryOperatorWordCondition
+    {
+    public:
+        NotEqualWordCondition(WordAccessor::Ptr &&left, WordAccessor::Ptr &&right) : BinaryOperatorWordCondition(std::move(left), std::move(right)) {}
+
+        virtual bool binary_operator_evaluate(const ieml::structure::Script::Ptr &left, const ieml::structure::Script::Ptr &right) const override
+        {
+            return left != right;
+        };
+    };
 
 }

--- a/src/ParserJsonSerializer.cpp
+++ b/src/ParserJsonSerializer.cpp
@@ -242,13 +242,12 @@ nlohmann::json _scriptToJson(ieml::structure::Script::Ptr script,
 }
 
 nlohmann::json _instanceToJson(ieml::structure::Link::Ptr link, ieml::structure::PathTree::Ptr element, std::vector<ieml::structure::ReferenceValue> instance,
-ieml::structure:: ReferenceSchema schema,
+                               ieml::structure::ReferenceSchema schema,
                                ieml::parser::ParserContextManager &context)
 {
 
     auto &cregister = context.getCategoryRegister();
     auto &wregister = context.getWordRegister();
-    auto &rregister = context.getReferenceSchemaRegister();
 
     const auto id = schema.uid(instance);
     const auto valuation = schema.valuation_from_reference_values(instance);
@@ -371,8 +370,7 @@ nlohmann::json ieml::parser::parserToJson(const IEMLParser &parser)
             {
                 const auto id = schema.uid(i);
 
-                instances[schema.uid(i)] = _instanceToJson(it.second, it.first, i, schema, *context);      
-
+                instances[schema.uid(i)] = _instanceToJson(it.second, it.first, i, schema, *context);
             }
         }
     }

--- a/src/grammar/IEMLLexerGrammar.g4
+++ b/src/grammar/IEMLLexerGrammar.g4
@@ -32,7 +32,11 @@ JUNCTION_CLOSE       : ']' ;
      
 REFERENCE_OPEN       : '<' ;
 REFERENCE_CLOSE      : '>' ;
-     
+
+EQUAL                : '==';
+NOTEQUAL             : '!=';
+
+
 SEMANTIC_ACCENT      : '!' ;
    
 DECLARATION_MARK     : '@' ;
@@ -47,7 +51,6 @@ PARENTHESIS_END      : ')';
 COMMA                : ',';
 
 MAPPING              : '->';
-EQUAL                : '==';
 
 VARIABLE             : '$'[0-9a-zA-Z]+;
 

--- a/src/grammar/IEMLParserGrammar.g4
+++ b/src/grammar/IEMLParserGrammar.g4
@@ -79,7 +79,9 @@ word_condition_function : PARENTHESIS_START word_condition_function_=word_condit
                         | word_condition_=word_condition                                                             # word_condition_function__word_condition
                         ;
 
-word_condition : left_accessor=word_accessor EQUAL right_accessor=word_accessor;
+word_condition : left_accessor=word_accessor EQUAL    right_accessor=word_accessor        # word_condition__equal
+               | left_accessor=word_accessor NOTEQUAL right_accessor=word_accessor        # word_condition__not_equal
+               ;
 
 word_accessor : accessor_=word_accessor_variable # word_accessor__variable
 							| word_literal=word # word_accessor__literal

--- a/test/grammar/test_declaration.cpp
+++ b/test/grammar/test_declaration.cpp
@@ -140,6 +140,7 @@ TEST(ieml_grammar_test_case, link_declaration_repeated_variable)                
 
 TEST(ieml_grammar_test_case, word_function)                                          TEST_PARSE_NO_ERRORS(WORD_FUNCTION_DECLARATION_PREFIX R"(@function type:word link:test domain:($A in "M:M:.", $B in "M:M:.") condition: $A.substance == $B.attribute and $A.attribute == $B.substance.)");
 TEST(ieml_grammar_test_case, word_function_literal)                                  TEST_PARSE_NO_ERRORS(WORD_FUNCTION_DECLARATION_PREFIX R"(@function type:word link:test domain:($A in "M:M:.", $B in "M:M:.") condition: $A.substance == $B.attribute and $A.attribute == "S:".)");
+TEST(ieml_grammar_test_case, word_function_inequality)                               TEST_PARSE_NO_ERRORS(WORD_FUNCTION_DECLARATION_PREFIX R"(@function type:word link:test domain:($A in "M:M:.", $B in "M:M:.") condition: $A.substance != $B.attribute.)");
 
 // ERRORS
 TEST(ieml_grammar_test_case, no_root)                                                TEST_PARSE_ERRORS(R"(@rootparadigm type:inflection "O:M:.".@rootparadigm type:category "O:O:.". @inflection en:noun class:NOUN "a.". @component en:test (1 ~noun #"wa.") .)");

--- a/test/structure/test_link.cpp
+++ b/test/structure/test_link.cpp
@@ -202,3 +202,80 @@ TEST(ieml_structure_test_case, link_word_auxiliary)
     const auto &refs = schema.getInstances();
     ASSERT_EQ(refs.size(), 4); // 4 auxiliary of the paradigm has been declared
 }
+
+TEST(ieml_structure_test_case, link_word_inequality)
+{
+    PARSE_NO_ERRORS(R"(
+        @rootparadigm type:auxiliary "E:.-F:.M:M:.-l.-'".
+        @word "A:".
+
+        @rootparadigm type:inflection "M:".
+        @inflection en: noun class:VERB "S:".
+
+        @auxiliary 
+            en:in
+            role:6
+            "E:.-T:.f.-l.-'".
+
+        @auxiliary 
+            fr:sous
+            en:under
+            role:6
+            "E:.-U:.f.-l.-'".
+
+        @auxiliary 
+            fr:fond
+            fr:base
+            fr:cul
+            en:bottom
+            en:basis
+            role:6
+            "E:.-U:.l.-l.-'".
+
+        @auxiliary 
+            fr:vers l'avant
+            en:ahead
+            en:to the front
+            role:6
+            "E:.-A:.s.-l.-'".
+
+        @link
+            args:($A, $B)
+            en:contains
+            template-en:$A est dans $B
+            template-fr:$A is in $B
+            phraseWordInflection: ~noun 
+            
+            (
+                0 #"A:",
+                1 #"A:" <$A>,
+                8 #"A:" <$B>
+            ).
+
+        @function
+            type:word
+            link:contains
+            domain:($A in "E:.-F:.M:M:.-l.-'", $B in "E:.-F:.M:M:.-l.-'")
+            condition:
+            (
+                $A != $B
+            ).
+    )");
+
+    const auto &ctx = parser.getContext();
+
+    auto &refreg = ctx->getReferenceSchemaRegister();
+    auto &linkreg = ctx->getLinkRegister();
+    auto &creg = ctx->getCategoryRegister();
+    auto &wreg = ctx->getWordRegister();
+    auto &preg = ctx->getPathTreeRegister();
+
+    const auto pt = creg.resolve_category(ieml::structure::LanguageString(ieml::structure::LanguageType::EN, "contains"));
+    ASSERT_NE(pt, nullptr);
+
+    ASSERT_TRUE(refreg.is_defined(pt));
+    const auto &schema = refreg.get_schema(pt);
+
+    const auto &refs = schema.getInstances();
+    ASSERT_EQ(refs.size(), 12); // 12 number of distincts couples in a set of size 4 (there are 4 nodes considered for a binary link)
+}


### PR DESCRIPTION
Allows the following syntax
```
@function
    type:word
    link:contains
    domain:($A in "E:.-F:.M:M:.-l.-'", $B in "E:.-F:.M:M:.-l.-'")
    condition:
    (
        $A != $B
    ).
```

It test for inequality between two scripts. This also works `$A.substance != $B.mode` or  `$A.substance != "A:"` 
 