### PR TITLE
Fix the bug that was triggered by the order of definiton of the node

### DIFF
--- a/include/ast/Phrase.h
+++ b/include/ast/Phrase.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <set>
 
-
 #include "ast/interfaces/AST.h"
 #include "ast/interfaces/IJunction.h"
 #include "ast/interfaces/ICategory.h"
@@ -14,125 +13,138 @@
 #include "ParserContextManager.h"
 #include "structure/path/PathNode.h"
 
+namespace ieml
+{
+    namespace AST
+    {
+        class Phrase : virtual public AST, public ICategory, public IReferenceValue
+        {
+        public:
+            Phrase() : ICategory(), IReferenceValue() {}
 
-namespace ieml {
-namespace AST {
-class Phrase: virtual public AST, public ICategory, public IReferenceValue {
-public:
-    Phrase() : ICategory(), IReferenceValue() {}
+            virtual PartialPathTree::Optional check_phrase(parser::ParserContextManager &ctx) const = 0;
 
-    virtual PartialPathTree::Optional check_phrase(parser::ParserContextManager& ctx) const = 0;
+            virtual PartialPathTree::Optional check_category(parser::ParserContextManager &ctx) const
+            {
+                return check_phrase(ctx);
+            };
+        };
 
-    virtual PartialPathTree::Optional check_category(parser::ParserContextManager& ctx) const {
-        return check_phrase(ctx);
-    };
+        class SimplePhrase : public Phrase
+        {
+        public:
+            SimplePhrase(CharRange::Ptr &&char_range,
+                         std::vector<std::shared_ptr<PhraseLine>> &&phrase_lines) : AST(std::move(char_range)),
+                                                                                    Phrase(),
+                                                                                    phrase_lines_(std::move(phrase_lines)) {}
 
-};
+            std::string to_string() const override
+            {
+                std::ostringstream os;
 
+                os << "(";
 
-class SimplePhrase : public Phrase {
-public:
-    SimplePhrase(CharRange::Ptr && char_range,
-                 std::vector<std::shared_ptr<PhraseLine>> && phrase_lines) : 
-            AST(std::move(char_range)),
-            Phrase(), 
-            phrase_lines_(std::move(phrase_lines)) {}
+                bool first = true;
+                for (auto &&line : phrase_lines_)
+                {
+                    if (first)
+                        first = false;
+                    else
+                        os << ", ";
 
-    std::string to_string() const override {
-        std::ostringstream os;
-
-        os << "(";
-
-        bool first = true;
-        for (auto&& line : phrase_lines_) {
-            if (first) first = false;
-            else os << ", ";
-
-            os << line->to_string();
-        }
-
-        os << ")";
-        return os.str();
-    }
-
-    virtual PartialPathTree::Optional check_phrase(parser::ParserContextManager& ctx) const override {
-        std::unordered_set<structure::RoleType> seen_nodes;
-        
-        std::vector<PartialPathTree::Optional> children_list;
-        children_list.reserve(phrase_lines_.size());
-
-        bool valid = true;
-        for (const auto& line: phrase_lines_) {
-            auto phrase_line_set = line->check_phrase_line(ctx);
-
-            if (!phrase_line_set) {
-                valid = false;
-                continue;
-            }
-            
-            auto role_number = std::dynamic_pointer_cast<structure::RoleNumberPathNode>((*phrase_line_set->getPathTrees().begin())->getNode());
-
-            if (!role_number) {
-                // should not occur
-                throw std::runtime_error("Not a role number path");
-            } else {
-                if (seen_nodes.count(role_number->getRoleType()) > 0) {
-                    ctx.getErrorManager().visitorError(
-                        line->getCharRange(),
-                        "Duplicated phrase line number."
-                    );
-                    valid = false;
-                } else {
-                    seen_nodes.insert(role_number->getRoleType());
-                    children_list.emplace_back(std::move(phrase_line_set));
+                    os << line->to_string();
                 }
+
+                os << ")";
+                return os.str();
             }
-        }
 
-        if (!valid)
-            return {};
+            virtual PartialPathTree::Optional check_phrase(parser::ParserContextManager &ctx) const override
+            {
+                std::unordered_set<structure::RoleType> seen_nodes;
 
-        if (seen_nodes.find(structure::RoleType::ROOT) == seen_nodes.end()) {
-            ctx.getErrorManager().visitorError(
-                getCharRange(),
-                "Missing root role."
-            );
-            return {};
-        }
+                std::vector<PartialPathTree::Optional> children_list;
+                children_list.reserve(phrase_lines_.size());
 
-        return PartialPathTree::product(ctx.getPathTreeRegister(), 
-                                        std::make_shared<structure::RootPathNode>(), 
-                                        std::move(children_list));
-    };
+                bool valid = true;
+                for (const auto &line : phrase_lines_)
+                {
+                    auto phrase_line_set = line->check_phrase_line(ctx);
 
+                    if (!phrase_line_set)
+                    {
+                        valid = false;
+                        continue;
+                    }
+                    auto node = (*phrase_line_set->getPathTrees().begin())->getNode();
+                    auto role_number = std::dynamic_pointer_cast<structure::RoleNumberPathNode>(node);
 
-private:
-    std::vector<std::shared_ptr<PhraseLine>> phrase_lines_;
+                    if (!role_number)
+                    {
+                        // should not occur
+                        throw std::runtime_error("Not a role number path");
+                    }
+                    else
+                    {
+                        if (seen_nodes.count(role_number->getRoleType()) > 0)
+                        {
+                            ctx.getErrorManager().visitorError(
+                                line->getCharRange(),
+                                "Duplicated phrase line number.");
+                            valid = false;
+                        }
+                        else
+                        {
+                            seen_nodes.insert(role_number->getRoleType());
+                            children_list.emplace_back(std::move(phrase_line_set));
+                        }
+                    }
+                }
 
-};
+                if (!valid)
+                    return {};
 
+                if (seen_nodes.find(structure::RoleType::ROOT) == seen_nodes.end())
+                {
+                    ctx.getErrorManager().visitorError(
+                        getCharRange(),
+                        "Missing root role.");
+                    return {};
+                }
 
-class JunctionPhrase : public Phrase, public IJunctionList<Phrase, structure::PhraseJunctionIndexPathNode, structure::PhraseJunctionPathNode, Empty> {
-public:
-    JunctionPhrase(CharRange::Ptr&& char_range,
-                   std::vector<std::shared_ptr<Phrase>>&& phrases,
-                   std::shared_ptr<IJunction>&& junction_identifier) : 
-        AST(std::move(char_range)),
-        Phrase(), 
-        IJunctionList<Phrase, structure::PhraseJunctionIndexPathNode, structure::PhraseJunctionPathNode, Empty>(std::move(phrases), std::move(junction_identifier)) {}
+                return PartialPathTree::product(ctx.getPathTreeRegister(),
+                                                std::make_shared<structure::RootPathNode>(),
+                                                std::move(children_list));
+            };
 
-    std::string to_string() const override {
-        return "(" + junction_to_string() + ")";
+        private:
+            std::vector<std::shared_ptr<PhraseLine>> phrase_lines_;
+        };
+
+        class JunctionPhrase : public Phrase, public IJunctionList<Phrase, structure::PhraseJunctionIndexPathNode, structure::PhraseJunctionPathNode, Empty>
+        {
+        public:
+            JunctionPhrase(CharRange::Ptr &&char_range,
+                           std::vector<std::shared_ptr<Phrase>> &&phrases,
+                           std::shared_ptr<IJunction> &&junction_identifier) : AST(std::move(char_range)),
+                                                                               Phrase(),
+                                                                               IJunctionList<Phrase, structure::PhraseJunctionIndexPathNode, structure::PhraseJunctionPathNode, Empty>(std::move(phrases), std::move(junction_identifier)) {}
+
+            std::string to_string() const override
+            {
+                return "(" + junction_to_string() + ")";
+            }
+
+            virtual PartialPathTree::Optional check_junction_item(parser::ParserContextManager &ctx, size_t i,
+                                                                  __attribute__((unused)) Empty a) const override
+            {
+                return items_[i]->check_phrase(ctx);
+            };
+
+            virtual PartialPathTree::Optional check_phrase(parser::ParserContextManager &ctx) const override
+            {
+                return check_junction(ctx, {});
+            }
+        };
     }
-    
-    virtual PartialPathTree::Optional check_junction_item(parser::ParserContextManager& ctx, size_t i, 
-                                                            __attribute__((unused)) Empty a) const override {
-        return items_[i]->check_phrase(ctx);
-    };
-
-    virtual PartialPathTree::Optional check_phrase(parser::ParserContextManager& ctx) const override {
-        return check_junction(ctx, {});
-    }
-};
-}
 }

--- a/include/structure/path/PathNode.h
+++ b/include/structure/path/PathNode.h
@@ -6,306 +6,368 @@
 #include <memory>
 #include <set>
 
+namespace ieml::structure
+{
 
+    class PathNode
+    {
+    public:
+        typedef std::shared_ptr<PathNode> Ptr;
 
-namespace ieml::structure {
+        virtual ~PathNode() = default;
 
-class PathNode {
-public:
+        virtual bool accept_next(const PathNode &next) const = 0;
 
-    typedef std::shared_ptr<PathNode> Ptr;
+        virtual PathType getPathType() const = 0;
 
-    virtual ~PathNode() = default;
+        bool operator==(const PathNode &a) const { return to_string() == a.to_string(); };
+        bool operator!=(const PathNode &a) const { return to_string() != a.to_string(); };
+        bool operator<(const PathNode &a) const
+        {
+            if (getPathType() == a.getPathType())
+                return comp(a) < 0;
+            else
+                return getPathType() < a.getPathType();
+        };
+        bool operator>(const PathNode &a) const
+        {
+            if (getPathType() == a.getPathType())
+                return comp(a) > 0;
+            else
+                return getPathType() > a.getPathType();
+        };
+        bool operator<=(const PathNode &a) const
+        {
+            if (getPathType() == a.getPathType())
+                return comp(a) <= 0;
+            else
+                return getPathType() < a.getPathType();
+        };
+        bool operator>=(const PathNode &a) const
+        {
+            if (getPathType() == a.getPathType())
+                return comp(a) >= 0;
+            else
+                return getPathType() > a.getPathType();
+        };
 
-    virtual bool accept_next(const PathNode& next) const = 0;
+        virtual std::string to_string() const = 0;
+        virtual const std::set<std::shared_ptr<Word>> getWords() const { return {}; };
 
-    virtual PathType getPathType() const = 0;
+        virtual size_t getIndex() const { throw std::invalid_argument("No index defined for " + std::string(getPathType()._to_string()) + " path node."); };
+        virtual RoleType getRoleType() const { throw std::invalid_argument("No RoleType defined for " + std::string(getPathType()._to_string()) + " path node."); };
+        virtual std::shared_ptr<JunctionWord> getJunctionType() const { throw std::invalid_argument("No JunctionWord defined for " + std::string(getPathType()._to_string()) + " path node."); };
 
-    bool operator==(const PathNode& a) const {return to_string() == a.to_string();};
-    bool operator!=(const PathNode& a) const {return to_string() != a.to_string();};
-    bool operator< (const PathNode& a) const {
-        if (getPathType() == a.getPathType()) return comp(a) <  0;
-        else                                  return getPathType() < a.getPathType();
+        virtual std::shared_ptr<AuxiliaryWord> getAuxialiryType() const { throw std::invalid_argument("No AuxiliaryWord defined for " + std::string(getPathType()._to_string()) + " path node."); };
+        virtual const std::set<std::shared_ptr<InflectionWord>> &getInflections() const { throw std::invalid_argument("No InflectionWords defined for " + std::string(getPathType()._to_string()) + " path node."); };
+        virtual const std::shared_ptr<CategoryWord> getCategoryWord() const { throw std::invalid_argument("No CategoryWord defined for " + std::string(getPathType()._to_string()) + " path node."); };
+
+        typedef std::set<std::shared_ptr<PathNode>> Set;
+        typedef std::vector<std::shared_ptr<PathNode>> Vector;
+
+        struct HashFunctor
+        {
+            size_t operator()(const ieml::structure::PathNode::Ptr &a) const;
+        };
+
+        struct EqualityFunctor
+        {
+            bool operator()(const ieml::structure::PathNode::Ptr &a, const ieml::structure::PathNode::Ptr &b) const
+            {
+                return *a == *b;
+            }
+        };
+
+    private:
+        virtual int comp(const PathNode &a) const = 0;
     };
-    bool operator> (const PathNode& a) const {
-        if (getPathType() == a.getPathType()) return comp(a) >  0;
-        else                                  return getPathType() > a.getPathType();
-    };
-    bool operator<=(const PathNode& a) const {
-        if (getPathType() == a.getPathType()) return comp(a) <= 0;
-        else                                  return getPathType() < a.getPathType();
-    };
-    bool operator>=(const PathNode& a) const {
-        if (getPathType() == a.getPathType()) return comp(a) >=  0;
-        else                                  return getPathType() > a.getPathType();
-    };
 
-    virtual std::string to_string() const = 0;
-    virtual const std::set<std::shared_ptr<Word>> getWords() const {return {};};
+    class RootPathNode : public PathNode
+    {
+    public:
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
 
-    virtual size_t getIndex() const {throw std::invalid_argument("No index defined for " +std::string(getPathType()._to_string())+ " path node.");};
-    virtual RoleType getRoleType() const {throw std::invalid_argument("No RoleType defined for " +std::string(getPathType()._to_string())+ " path node.");};
-    virtual std::shared_ptr<JunctionWord> getJunctionType() const {throw std::invalid_argument("No JunctionWord defined for " +std::string(getPathType()._to_string())+ " path node.");};
-
-    virtual std::shared_ptr<AuxiliaryWord> getAuxialiryType() const {throw std::invalid_argument("No AuxiliaryWord defined for " +std::string(getPathType()._to_string())+ " path node.");};
-    virtual const std::set<std::shared_ptr<InflectionWord>>& getInflections() const {throw std::invalid_argument("No InflectionWords defined for " +std::string(getPathType()._to_string())+ " path node.");};
-    virtual const std::shared_ptr<CategoryWord> getCategoryWord() const {throw std::invalid_argument("No CategoryWord defined for " +std::string(getPathType()._to_string())+ " path node.");};
-
-
-    typedef std::set<std::shared_ptr<PathNode>> Set;
-    typedef std::vector<std::shared_ptr<PathNode>> Vector;
-
-
-    struct HashFunctor {
-        size_t operator()(const ieml::structure::PathNode::Ptr& a) const;
+    private:
+        virtual int comp(__attribute__((unused)) const PathNode &a) const override { return 0; };
     };
 
-    struct EqualityFunctor {
-        bool operator()(const ieml::structure::PathNode::Ptr& a, const ieml::structure::PathNode::Ptr& b) const {
-            return *a == *b;
+    class ParadigmPathNode : public PathNode
+    {
+    public:
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
+
+    private:
+        virtual int comp(__attribute__((unused)) const PathNode &a) const override { return 0; };
+    };
+
+    class ParadigmIndexPathNode : public PathNode
+    {
+    public:
+        ParadigmIndexPathNode(size_t index) : index_(index){};
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
+
+        virtual size_t getIndex() const override { return index_; };
+
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (getIndex() == a.getIndex())
+                return 0;
+            if (getIndex() < a.getIndex())
+                return -1;
+            else
+                return 1;
+        };
+
+        const size_t index_;
+    };
+
+    class RoleNumberPathNode : public PathNode
+    {
+    public:
+        RoleNumberPathNode(RoleType role_type) : role_type_(role_type){};
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
+
+        virtual RoleType getRoleType() const override { return role_type_; };
+
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (getRoleType() == a.getRoleType())
+                return 0;
+            if (getRoleType() < a.getRoleType())
+                return -1;
+            else
+                return 1;
+        };
+
+        const RoleType role_type_;
+    };
+
+    class JunctionPathNode : public PathNode
+    {
+    public:
+        JunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : junction_type_(junction_type) {}
+        virtual std::string to_string() const override;
+
+        virtual std::shared_ptr<JunctionWord> getJunctionType() const override { return junction_type_; };
+        virtual const std::set<std::shared_ptr<Word>> getWords() const override { return {junction_type_}; };
+
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (*getJunctionType() == *a.getJunctionType())
+                return 0;
+            if (*getJunctionType() < *a.getJunctionType())
+                return -1;
+            else
+                return 1;
+        };
+
+        const std::shared_ptr<JunctionWord> junction_type_;
+    };
+
+    class PhraseJunctionPathNode : public JunctionPathNode
+    {
+    public:
+        PhraseJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class AuxiliaryJunctionPathNode : public JunctionPathNode
+    {
+    public:
+        AuxiliaryJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class InflectionJunctionPathNode : public JunctionPathNode
+    {
+    public:
+        InflectionJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class CategoryJunctionPathNode : public JunctionPathNode
+    {
+    public:
+        CategoryJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class JunctionIndexPathNode : public PathNode
+    {
+    public:
+        JunctionIndexPathNode(size_t index) : index_(index) {}
+        virtual std::string to_string() const override;
+
+        virtual size_t getIndex() const override { return index_; };
+
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (getIndex() == a.getIndex())
+                return 0;
+            if (getIndex() < a.getIndex())
+                return -1;
+            else
+                return 1;
+        };
+
+        const size_t index_;
+    };
+
+    class PhraseJunctionIndexPathNode : public JunctionIndexPathNode
+    {
+    public:
+        PhraseJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class AuxiliaryJunctionIndexPathNode : public JunctionIndexPathNode
+    {
+    public:
+        AuxiliaryJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class InflectionJunctionIndexPathNode : public JunctionIndexPathNode
+    {
+    public:
+        InflectionJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class CategoryJunctionIndexPathNode : public JunctionIndexPathNode
+    {
+    public:
+        CategoryJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+    };
+
+    class AuxiliaryPathNode : public PathNode
+    {
+    public:
+        AuxiliaryPathNode(std::shared_ptr<AuxiliaryWord> auxiliary_type) : auxiliary_type_(auxiliary_type) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
+        virtual const std::set<std::shared_ptr<Word>> getWords() const override { return {auxiliary_type_}; };
+
+        virtual std::shared_ptr<AuxiliaryWord> getAuxialiryType() const override { return auxiliary_type_; };
+
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (*getAuxialiryType() == *a.getAuxialiryType())
+                return 0;
+            if (*getAuxialiryType() < *a.getAuxialiryType())
+                return -1;
+            else
+                return 1;
+        };
+
+        const std::shared_ptr<AuxiliaryWord> auxiliary_type_;
+    };
+
+    class InflectionPathNode : public PathNode
+    {
+    public:
+        InflectionPathNode(const std::set<std::shared_ptr<InflectionWord>> &inflections) : inflections_(inflections) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
+
+        virtual const std::set<std::shared_ptr<Word>> getWords() const override
+        {
+            return std::set<std::shared_ptr<Word>>(inflections_.begin(), inflections_.end());
+        };
+
+        virtual const std::set<std::shared_ptr<InflectionWord>> &getInflections() const override { return inflections_; };
+
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (getInflections().size() != a.getInflections().size())
+                return (getInflections().size() < a.getInflections().size() ? -1 : 1);
+
+            auto it_a = a.getInflections().begin();
+            for (auto it_self = getInflections().begin(); it_self != getInflections().end(); it_self++)
+            {
+                if (**it_self != **it_a)
+                    return (**it_self < **it_a ? -1 : 1);
+                it_a++;
+            }
+            // they are equal
+            return 0;
         }
+
+        const std::set<std::shared_ptr<InflectionWord>> inflections_;
     };
 
+    /*
+     * WordPathNode
+     *
+     * The terminal path to a category Word
+     */
+    class WordPathNode : public PathNode
+    {
+    public:
+        WordPathNode(std::shared_ptr<CategoryWord> word) : word_(word) {}
+        virtual bool accept_next(const PathNode &next) const override;
+        virtual PathType getPathType() const override;
+        virtual std::string to_string() const override;
 
-private:
-    virtual int comp(const PathNode& a) const = 0;
-};
+        virtual const std::set<std::shared_ptr<Word>> getWords() const override
+        {
+            return {word_};
+        };
 
-class RootPathNode : public PathNode {
-public:
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
+        virtual const std::shared_ptr<CategoryWord> getCategoryWord() const override { return word_; };
 
-private:
-    virtual int comp(__attribute__((unused)) const PathNode& a) const override {return 0;};
-};
+    private:
+        virtual int comp(const PathNode &a) const override
+        {
+            if (*getCategoryWord() == *a.getCategoryWord())
+                return 0;
+            if (*getCategoryWord() < *a.getCategoryWord())
+                return -1;
+            else
+                return 1;
+        };
 
-class ParadigmPathNode : public PathNode {
-public:
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
-
-private:
-    virtual int comp(__attribute__((unused)) const PathNode& a) const override {return 0;};
-};
-
-class ParadigmIndexPathNode : public PathNode {
-public:
-    ParadigmIndexPathNode(size_t index) : index_(index) {};
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
-
-    virtual size_t getIndex() const override {return index_;};
-
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (getIndex() == a.getIndex()) return  0;
-        if (getIndex() <  a.getIndex()) return -1;
-        else                            return  1;
+        const std::shared_ptr<CategoryWord> word_;
     };
-
-    const size_t index_;
-};
-
-
-
-class RoleNumberPathNode : public PathNode {
-public:
-    RoleNumberPathNode(RoleType role_type) : role_type_(role_type) {};
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
-
-    virtual RoleType getRoleType() const override {return role_type_;};
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (getRoleType() == a.getRoleType()) return  0;
-        if (getRoleType() <  a.getRoleType()) return -1;
-        else                            return  1;
-    };
-
-    const RoleType role_type_;
-};
-
-
-class JunctionPathNode : public PathNode {
-public:
-    JunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : junction_type_(junction_type) {}
-    virtual std::string to_string() const override;
-
-    virtual std::shared_ptr<JunctionWord> getJunctionType() const override {return junction_type_;};
-    virtual const std::set<std::shared_ptr<Word>> getWords() const override {return {junction_type_};};
-
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (*getJunctionType() == *a.getJunctionType()) return  0;
-        if (*getJunctionType() <  *a.getJunctionType()) return -1;
-        else                                            return  1;
-    };
-
-    const std::shared_ptr<JunctionWord> junction_type_;
-};
-
-class PhraseJunctionPathNode : public JunctionPathNode {
-public:
-    PhraseJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class AuxiliaryJunctionPathNode : public JunctionPathNode {
-public:
-    AuxiliaryJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class InflectionJunctionPathNode : public JunctionPathNode {
-public:
-    InflectionJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class CategoryJunctionPathNode : public JunctionPathNode {
-public:
-    CategoryJunctionPathNode(std::shared_ptr<JunctionWord> junction_type) : JunctionPathNode(junction_type) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class JunctionIndexPathNode : public PathNode {
-public:
-    JunctionIndexPathNode(size_t index) : index_(index) {}
-    virtual std::string to_string() const override;
-
-    virtual size_t getIndex() const override {return index_;};
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (getIndex() == a.getIndex()) return  0;
-        if (getIndex() <  a.getIndex()) return -1;
-        else                    return  1;
-    };
-
-    const size_t index_;
-};
-
-class PhraseJunctionIndexPathNode : public JunctionIndexPathNode {
-public:
-    PhraseJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class AuxiliaryJunctionIndexPathNode : public JunctionIndexPathNode {
-public:
-    AuxiliaryJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class InflectionJunctionIndexPathNode : public JunctionIndexPathNode {
-public:
-    InflectionJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class CategoryJunctionIndexPathNode : public JunctionIndexPathNode {
-public:
-    CategoryJunctionIndexPathNode(size_t index) : JunctionIndexPathNode(index) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-};
-
-class AuxiliaryPathNode : public PathNode {
-public:
-    AuxiliaryPathNode(std::shared_ptr<AuxiliaryWord> auxiliary_type) : auxiliary_type_(auxiliary_type) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
-    virtual const std::set<std::shared_ptr<Word>> getWords() const override {return {auxiliary_type_};};
-
-    virtual std::shared_ptr<AuxiliaryWord> getAuxialiryType() const override {return auxiliary_type_;};
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (*getAuxialiryType() == *a.getAuxialiryType()) return  0;
-        if (*getAuxialiryType() <  *a.getAuxialiryType()) return -1;
-        else                                        return  1;
-    };
-
-    const std::shared_ptr<AuxiliaryWord> auxiliary_type_;
-};
-
-class InflectionPathNode : public PathNode {
-public:
-    InflectionPathNode(const std::set<std::shared_ptr<InflectionWord>>& inflections) : inflections_(inflections) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
-
-    virtual const std::set<std::shared_ptr<Word>> getWords() const override {
-        return std::set<std::shared_ptr<Word>>(inflections_.begin(), inflections_.end());
-    };
-
-    virtual const std::set<std::shared_ptr<InflectionWord>>& getInflections() const override {return inflections_;};
-
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (getInflections().size() != a.getInflections().size()) return (getInflections().size() < a.getInflections().size() ? -1 : 1);
-
-        auto it_a = a.getInflections().begin();
-        for (auto it_self = getInflections().begin(); it_self != getInflections().end(); it_self++) {
-            if (**it_self != **it_a) return (**it_self < **it_a ? -1 : 1);
-            it_a++;
-        }
-        // they are equal
-        return 0;
-    }
-
-    const std::set<std::shared_ptr<InflectionWord>> inflections_;
-};
-
-/*
- * WordPathNode
- *
- * The terminal path to a category Word
- */
-class WordPathNode : public PathNode {
-public:
-    WordPathNode(std::shared_ptr<CategoryWord> word) : word_(word) {}
-    virtual bool accept_next(const PathNode& next) const override;
-    virtual PathType getPathType() const override;
-    virtual std::string to_string() const override;
-
-    virtual const std::set<std::shared_ptr<Word>> getWords() const override {
-        return {word_};
-    };
-
-    virtual const std::shared_ptr<CategoryWord> getCategoryWord() const override {return word_;};
-private:
-    virtual int comp(const PathNode& a) const override {
-        if (*getCategoryWord() == *a.getCategoryWord()) return  0;
-        if (*getCategoryWord() <  *a.getCategoryWord()) return -1;
-        else                                            return  1;
-    };
-
-    const std::shared_ptr<CategoryWord> word_;
-};
 
 }
 
-
-namespace std {
-template<>
-struct hash<ieml::structure::PathNode>
+namespace std
 {
-    size_t operator()(const ieml::structure::PathNode& s) const noexcept
+    template <>
+    struct hash<ieml::structure::PathNode>
     {
-        return hash<string>{}(s.to_string());
-    }
-};
+        size_t operator()(const ieml::structure::PathNode &s) const noexcept
+        {
+            size_t seed = 0;
+            hash_combine(seed, s.getPathType());
+            hash_combine(seed, s.to_string());
+            return seed;
+        }
+    };
 }

--- a/test/grammar/test_paradigm.cpp
+++ b/test/grammar/test_paradigm.cpp
@@ -148,3 +148,16 @@ TEST(ieml_grammar_test_case, no_regression_missing_invariant)
                        @paranode en:paradigm 1d: /#/2 (0 #"a.", 1 #"b.", 2 #(0 #"a.", 1 {#var1; #var2})).)");
     }
 }
+
+TEST(ieml_grammar_test_case, no_regression_crash_order_of_definition)
+{
+    PARSE_NO_ERRORS(R"(
+        @word "A:A:A:.".
+        @word "B:B:B:.".
+        @word "T:T:T:.".
+
+        @node en:invariant (0 #"A:A:A:.").
+        @paranode en:paranode 1d:/#/1 (0 #"A:A:A:.", 1 { #(0 #"B:B:B:.") ; #(0 #"T:T:T:.")}).
+        @node en:should not crash (0 #(0 #"B:B:B:.")).
+    )");
+}


### PR DESCRIPTION
This was caused by a buggy implementation of the hashing of PathNodes. A PARANODE_INDEX was equal to a ROLE with the same number. This was causing errors when a paranode was declared before a node that correspond to a substring of the paranode paths.