### PR TITLE
Make subphrase variation in paranode not accounted for

### DIFF
--- a/include/structure/path/PathTree.h
+++ b/include/structure/path/PathTree.h
@@ -120,11 +120,20 @@ namespace ieml::structure
 
             /**
              * @brief Return the invariant path Set of a PathTree.
-             *        This correspond to the path tree without the roles, at any subphrase depth, containing a variation group.
+             *        This correspond to the path tree without the roles containing a variation group.
+             *        This method does not account for nested subphrases.
              *
              * @return Set
              */
             Set invariant_paths(const PathTree::Ptr &);
+
+            /**
+             * @brief Return the invariant path Set of a PathTree.
+             *        This correspond to the path tree without the roles, at any subphrase depth, containing a variation group.
+             *
+             * @return Set
+             */
+            Set invariant_paths2(const PathTree::Ptr &);
 
             /**
              * @brief For a singular sequence, return the same as paths. For a paradigm, return the intersection

--- a/src/structure/path/PathTree.cpp
+++ b/src/structure/path/PathTree.cpp
@@ -269,8 +269,78 @@ PathTree::Set PathTree::Register::paths(const PathTree::Ptr &pt)
 
     return res;
 }
-
 PathTree::Set PathTree::Register::invariant_paths(const PathTree::Ptr &paradigm)
+{
+    PathTree::Vector singular_sequences = PathTree::singular_sequences(paradigm);
+    auto it = singular_sequences.begin();
+
+    std::unordered_map<PathTree::Ptr, PathTree::Ptr> prefix_to_subtree;
+
+    auto is_role = [](const PathTree::Ptr &pt)
+    { return pt->is_role(); };
+
+    auto subtrees = (*it)->find_sub_tree(
+        *this,
+        is_role,
+        is_role);
+    for (auto pair : subtrees)
+    {
+        // append the role number at the end of the prefix (not included by default)
+        auto path = this->concat(pair.first, this->get_or_create(pair.second->getNode()));
+        prefix_to_subtree.insert({path, *pair.second->getChildren().begin()});
+    }
+    ++it;
+    while (it != singular_sequences.end())
+    {
+        auto subtrees = (*it)->find_sub_tree(
+            *this,
+            is_role,
+            is_role);
+
+        std::unordered_map<PathTree::Ptr, PathTree::Ptr> prefix_to_subtree_curr;
+
+        for (auto pair : subtrees)
+        {
+            // append the role number at the end of the prefix (not included by default)
+            auto path = this->concat(pair.first, this->get_or_create(pair.second->getNode()));
+            prefix_to_subtree_curr.insert({path, *pair.second->getChildren().begin()});
+        }
+
+        std::unordered_map<PathTree::Ptr, PathTree::Ptr> prefix_to_subtree_new;
+
+        for (auto it_old = prefix_to_subtree.begin(); it_old != prefix_to_subtree.end(); it_old++)
+        {
+            auto value_it = prefix_to_subtree_curr.find(it_old->first);
+
+            if (value_it == prefix_to_subtree_curr.end())
+            {
+                continue;
+            }
+            if (value_it->second != it_old->second)
+            {
+                continue;
+            }
+
+            prefix_to_subtree_new.insert(*it_old);
+        }
+
+        prefix_to_subtree = prefix_to_subtree_new;
+        ++it;
+    }
+
+    PathTree::Set paths;
+    for (auto pair : prefix_to_subtree)
+    {
+        for (auto path : this->paths(this->concat(pair.first, pair.second)))
+        {
+            paths.insert(path);
+        }
+    }
+
+    return paths;
+}
+
+PathTree::Set PathTree::Register::invariant_paths2(const PathTree::Ptr &paradigm)
 {
     PathTree::Vector singular_sequences = PathTree::singular_sequences(paradigm);
 

--- a/test/grammar/test_paradigm.cpp
+++ b/test/grammar/test_paradigm.cpp
@@ -139,12 +139,21 @@ TEST(ieml_grammar_test_case, no_regression_missing_invariant)
                        @node en:invariant (0 #"a.", 1 #"b.").
                        @paranode en:paradigm 1d: /#/2 (0 #"a.", 1 #"b.", 2 {#var1; #var2}).)");
     }
+    // This test ensure that subphrase are supported in paranode. (not supported)
+    // {
+    //     // the variation is in a sub phrase
+    //     PARSE_NO_ERRORS(R"(@word "a.". @word "b.". @word "c.". @word "d.".
+    //                    @node en:var1 (0 #"d.", 1 #"b.").
+    //                    @node en:var2 (0 #"c.", 1 #"b.").
+    //                    @node en:invariant (0 #"a.", 1 #"b.", 2 #(0 #"a.")).
+    //                    @paranode en:paradigm 1d: /#/2 (0 #"a.", 1 #"b.", 2 #(0 #"a.", 1 {#var1; #var2})).)");
+    // }
     {
-        // the variation is in a sub phrase
+        // the variation is in a sub phrase.
         PARSE_NO_ERRORS(R"(@word "a.". @word "b.". @word "c.". @word "d.".
                        @node en:var1 (0 #"d.", 1 #"b.").
                        @node en:var2 (0 #"c.", 1 #"b.").
-                       @node en:invariant (0 #"a.", 1 #"b.", 2 #(0 #"a.")).
+                       @node en:invariant (0 #"a.", 1 #"b.").
                        @paranode en:paradigm 1d: /#/2 (0 #"a.", 1 #"b.", 2 #(0 #"a.", 1 {#var1; #var2})).)");
     }
 }


### PR DESCRIPTION
Revert changes in a previous PR : makes the invariant of paranodes not aware for variation in subphrases.

The invariant is now always the paranode without any role at the root level containing variation.